### PR TITLE
Redo new member flow

### DIFF
--- a/src/commands/afaf.ts
+++ b/src/commands/afaf.ts
@@ -57,7 +57,7 @@ export async function execute(interaction: CommandInteraction<CacheType>) {
             project: 'blacc',
             channel: 'general',
             event: `Someone asked anonymously in #${channel.name}`,
-            description: `Called by ${member.id}`,
+            description: `Called by ${member.user.tag}`,
             icon: '❓',
             notify: true,
         }),

--- a/src/commands/intro.ts
+++ b/src/commands/intro.ts
@@ -86,7 +86,7 @@ export async function execute(interaction: CommandInteraction<CacheType>) {
                 ],
             }),
             interaction.reply({ content: 'Welcome to the server!', ephemeral: true }),
-            deleteOnBoardingMessage(member),
+            deleteOnBoardingMessage(interaction, member),
         ]);
 
         await logger({

--- a/src/commands/intro.ts
+++ b/src/commands/intro.ts
@@ -1,4 +1,4 @@
-import { CommandInteraction, CacheType, GuildMember, TextChannel, Message } from 'discord.js';
+import { CommandInteraction, CacheType, GuildMember } from 'discord.js';
 import { SlashCommandBuilder } from '@discordjs/builders';
 import { CONSTANTS } from '../constants';
 import { formatSocial, socials } from '../utils';

--- a/src/commands/intro.ts
+++ b/src/commands/intro.ts
@@ -1,4 +1,4 @@
-import { CommandInteraction, CacheType, GuildMember } from 'discord.js';
+import { CommandInteraction, CacheType, GuildMember, TextChannel } from 'discord.js';
 import { SlashCommandBuilder } from '@discordjs/builders';
 import { CONSTANTS } from '../constants';
 import { formatSocial, socials } from '../utils';
@@ -6,6 +6,7 @@ import { embedMessage } from '../utils/embed-message';
 import { updateProfile } from '../lib/updateProfile';
 import { deleteOnBoardingMessage } from '../lib/deleteMessage';
 import logger from '../utils/logger';
+import { addMemberStatusRole } from '../lib/addMemberStatusRole';
 
 export const data = new SlashCommandBuilder()
     .setName('intro')
@@ -44,6 +45,9 @@ export const data = new SlashCommandBuilder()
 
 export async function execute(interaction: CommandInteraction<CacheType>) {
     const channel = interaction.channel;
+    const welcomeChannel = interaction.client.channels.cache.get(
+        CONSTANTS.WELCOME_CHANNEL_ID,
+    ) as TextChannel;
     const member = interaction.member as GuildMember;
     const status = interaction.options.get('status');
     const github = interaction.options.get('github');
@@ -61,45 +65,43 @@ export async function execute(interaction: CommandInteraction<CacheType>) {
         };
     });
 
-    if (channel?.id !== CONSTANTS.WELCOME_CHANNEL_ID) {
+    if (
+        channel?.id !== CONSTANTS.ONBOARDING_CHANNEL_ID ||
+        !member.roles.cache.has(CONSTANTS.ONBOARDING_ROLE_ID)
+    ) {
         await interaction.reply({
-            content: `You can only use this command in the welcome channel.`,
+            content: `You can only use this command in the onboarding channel.`,
             ephemeral: true,
         });
         return;
     }
 
-    if (!member.roles.cache.has(CONSTANTS.MEMBER_ROLE_ID)) {
-        await Promise.all([
-            member.roles.add(CONSTANTS.MEMBER_ROLE_ID),
-            member.roles.remove(CONSTANTS.ONBOARDING_ROLE_ID),
-            updateProfile({ id: member.id, status, links, intro }),
-            channel?.send({
-                embeds: [
-                    embedMessage({
-                        title: `Welcome ${member.displayName}!`,
-                        description: `${intro}`,
-                        color: '#5bd64b',
-                        thumbnail: member.user.displayAvatarURL(),
-                        links,
-                    }),
-                ],
-            }),
-            interaction.reply({ content: 'Welcome to the server!', ephemeral: true }),
-            deleteOnBoardingMessage(interaction, member),
-        ]);
-
-        await logger({
+    await Promise.all([
+        member.roles.remove(CONSTANTS.ONBOARDING_ROLE_ID),
+        member.roles.add(CONSTANTS.MEMBER_ROLE_ID),
+        addMemberStatusRole(member, status!),
+        updateProfile({ id: member.user.tag, status, links, intro }),
+        interaction.reply('Thank you for introducing yourself! Go check out the other channels!'),
+        deleteOnBoardingMessage(interaction, member),
+        welcomeChannel?.send({
+            embeds: [
+                embedMessage({
+                    title: `Welcome ${member.displayName}!`,
+                    description: `${intro}`,
+                    color: '#5bd64b',
+                    thumbnail: member.user.displayAvatarURL(),
+                    links,
+                    status: status?.value as string,
+                }),
+            ],
+        }),
+        logger({
             project: 'blacc',
             channel: 'welcome',
             event: 'New introduction',
             description: member.user.tag,
             icon: '👋',
             notify: true,
-        });
-        return;
-    }
-
-    await updateProfile({ id: member.id, status, links, intro });
-    await interaction.reply({ content: `Thank you for another intro!`, ephemeral: true });
+        }),
+    ]);
 }

--- a/src/commands/list-topics.ts
+++ b/src/commands/list-topics.ts
@@ -24,7 +24,7 @@ export async function execute(interaction: CommandInteraction<CacheType>) {
             project: 'blacc',
             channel: 'general',
             event: 'Listing WCW topics',
-            description: `Called by ${member.id}`,
+            description: `Called by ${member.user.tag}`,
             icon: '👂🏿',
             notify: true,
         }),

--- a/src/commands/remove-topic.ts
+++ b/src/commands/remove-topic.ts
@@ -35,7 +35,7 @@ export async function execute(interaction: CommandInteraction<CacheType>) {
             project: 'blacc',
             channel: 'general',
             event: `Topic ${topicId} has been removed`,
-            description: `Called by ${member.id}`,
+            description: `Called by ${member.user.tag}`,
             icon: '🗑️',
             notify: true,
         }),

--- a/src/commands/update-profile.ts
+++ b/src/commands/update-profile.ts
@@ -109,7 +109,7 @@ export async function execute(interaction: CommandInteraction<CacheType>) {
     const updatedLinks = getUpdatedLinks(oldLinks, newLinks);
 
     const updatedValues = {
-        id: member.id,
+        id: member.user.tag,
         status: updatedStatus,
         intro: updatedIntro,
         links: updatedLinks,

--- a/src/commands/update-topic.ts
+++ b/src/commands/update-topic.ts
@@ -38,7 +38,7 @@ export async function execute(interaction: CommandInteraction<CacheType>) {
             project: 'blacc',
             channel: 'general',
             event: `Topic ${topicId} has been updated`,
-            description: `Called by ${member.id}`,
+            description: `Called by ${member.user.tag}`,
             icon: '🟢',
             notify: true,
         }),

--- a/src/commands/update-wcw.ts
+++ b/src/commands/update-wcw.ts
@@ -33,7 +33,7 @@ export async function execute(interaction: CommandInteraction<CacheType>) {
             project: 'blacc',
             channel: 'general',
             event: 'WCW topic added',
-            description: `Called by ${member.id}`,
+            description: `Called by ${member.user.tag}`,
             icon: '🟢',
             notify: true,
         }),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,6 +10,7 @@ export const CONSTANTS = Object.freeze({
     GENERAL_CHANNEL_ID: process.env.GENERAL_CHANNEL_ID as string,
     MODERATOR_CHANNEL_ID: process.env.MODERATOR_CHANNEL_ID as string,
     WELCOME_CHANNEL_ID: process.env.WELCOME_CHANNEL_ID as string,
+    ONBOARDING_CHANNEL_ID: process.env.ONBOARDING_CHANNEL_ID as string,
     COMMUNITY_GUIDELINES_CHANNEL_ID: process.env.COMMUNITY_GUIDELINES_CHANNEL_ID as string,
     COMMUNITY_GUIDELINES_MESSAGE_ID: process.env.COMMUNITY_GUIDELINES_MESSAGE_ID as string,
     BOT_INTENTS: [
@@ -19,7 +20,7 @@ export const CONSTANTS = Object.freeze({
         Intents.FLAGS.GUILD_MESSAGE_REACTIONS,
     ],
     BOT_PARTIALS: ['MESSAGE', 'CHANNEL', 'REACTION'] as PartialTypes[],
-    SPECTATOR_ROLE_ID: process.env.SPECTATOR_ROLE_ID as string,
+    ONBOARDING_ROLE_ID: process.env.ONBOARDING_ROLE_ID as string,
     MEMBER_ROLE_ID: process.env.MEMBER_ROLE_ID as string,
     MODERATOR_ROLE_ID: process.env.MODERATOR_ROLE_ID as string,
     _5_SECONDS: 5000,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,9 +10,16 @@ export const CONSTANTS = Object.freeze({
     GENERAL_CHANNEL_ID: process.env.GENERAL_CHANNEL_ID as string,
     MODERATOR_CHANNEL_ID: process.env.MODERATOR_CHANNEL_ID as string,
     WELCOME_CHANNEL_ID: process.env.WELCOME_CHANNEL_ID as string,
+    SPECTATOR_ROLE_ID: process.env.SPECTATOR_ROLE_ID as string,
     ONBOARDING_CHANNEL_ID: process.env.ONBOARDING_CHANNEL_ID as string,
     COMMUNITY_GUIDELINES_CHANNEL_ID: process.env.COMMUNITY_GUIDELINES_CHANNEL_ID as string,
     COMMUNITY_GUIDELINES_MESSAGE_ID: process.env.COMMUNITY_GUIDELINES_MESSAGE_ID as string,
+    MEMBER_STATUSES: {
+        Aspiring: process.env.ASPIRING_ROLE_ID as string,
+        Junior: process.env.JUNIOR_DEVELOPER_ROLE_ID as string,
+        Senior: process.env.SENIOR_DEVELOPER_ROLE_ID as string,
+        'Mid-level': process.env.MID_LEVEL_ROLE_ID as string,
+    },
     BOT_INTENTS: [
         Intents.FLAGS.GUILDS,
         Intents.FLAGS.GUILD_MEMBERS,

--- a/src/events/messageReactionAdd.ts
+++ b/src/events/messageReactionAdd.ts
@@ -29,11 +29,8 @@ export const execute = async (reaction: MessageReaction, user: User) => {
                 `Hey <@${member.id}>! \nCheck the pinned message 👆 for instructions on how to use the /intro slash command so you can introduce yourself and get access to all channels 😎`,
             ),
         ]);
-    } else if (member.roles.cache.has(CONSTANTS.ONBOARDING_ROLE_ID)) {
-        await Promise.all([
-            member.roles.remove(CONSTANTS.ONBOARDING_ROLE_ID),
-            member.roles.add(CONSTANTS.MEMBER_ROLE_ID),
-        ]);
+    } else {
+        await member.roles.remove(CONSTANTS.SPECTATOR_ROLE_ID);
     }
 
     await logger({

--- a/src/events/messageReactionAdd.ts
+++ b/src/events/messageReactionAdd.ts
@@ -26,7 +26,7 @@ export const execute = async (reaction: MessageReaction, user: User) => {
         await Promise.all([
             member.roles.add(CONSTANTS.ONBOARDING_ROLE_ID),
             channel.send(
-                `Hey <@${member.id}>! \nCheck the pinned message 👆 for instructions on how to use the slash command so you can introduce yourself and get access to all channels 😎`,
+                `Hey <@${member.id}>! \nCheck the pinned message 👆 for instructions on how to use the /intro slash command so you can introduce yourself and get access to all channels 😎`,
             ),
         ]);
     } else if (member.roles.cache.has(CONSTANTS.ONBOARDING_ROLE_ID)) {

--- a/src/events/messageReactionAdd.ts
+++ b/src/events/messageReactionAdd.ts
@@ -1,4 +1,4 @@
-import { MessageReaction, User } from 'discord.js';
+import { MessageReaction, TextChannel, User } from 'discord.js';
 import { client } from '..';
 import { CONSTANTS } from '../constants';
 import logger from '../utils/logger';
@@ -20,12 +20,20 @@ export const execute = async (reaction: MessageReaction, user: User) => {
 
     const guild = await client.guilds.fetch(CONSTANTS.GUILD_ID);
     const member = await guild.members.fetch(user.id);
+    const channel = guild.channels.cache.get(CONSTANTS.ONBOARDING_CHANNEL_ID) as TextChannel;
 
     if (member.roles.cache.every(role => role.name === '@everyone')) {
-        await member.roles.add(CONSTANTS.SPECTATOR_ROLE_ID);
-    } else if (member.roles.cache.has(CONSTANTS.SPECTATOR_ROLE_ID)) {
-        await member.roles.remove(CONSTANTS.SPECTATOR_ROLE_ID);
-        await member.roles.add(CONSTANTS.MEMBER_ROLE_ID);
+        await Promise.all([
+            member.roles.add(CONSTANTS.ONBOARDING_ROLE_ID),
+            channel.send(
+                `Hey <@${member.id}>! \nCheck the pinned message 👆 for instructions on how to use the slash command so you can introduce yourself and get access to all channels 😎`,
+            ),
+        ]);
+    } else if (member.roles.cache.has(CONSTANTS.ONBOARDING_ROLE_ID)) {
+        await Promise.all([
+            member.roles.remove(CONSTANTS.ONBOARDING_ROLE_ID),
+            member.roles.add(CONSTANTS.MEMBER_ROLE_ID),
+        ]);
     }
 
     await logger({

--- a/src/events/messageReactionRemove.ts
+++ b/src/events/messageReactionRemove.ts
@@ -11,11 +11,11 @@ export const execute = async (reaction: MessageReaction, user: User) => {
     const guild = await client.guilds.fetch(CONSTANTS.GUILD_ID);
     const member = await guild.members.fetch(user.id);
 
-    if (member.roles.cache.has(CONSTANTS.SPECTATOR_ROLE_ID)) {
-        await member.roles.remove(CONSTANTS.SPECTATOR_ROLE_ID);
+    if (member.roles.cache.has(CONSTANTS.ONBOARDING_ROLE_ID)) {
+        await member.roles.remove(CONSTANTS.ONBOARDING_ROLE_ID);
     } else if (member.roles.cache.has(CONSTANTS.MEMBER_ROLE_ID)) {
         await member.roles.remove(CONSTANTS.MEMBER_ROLE_ID);
-        await member.roles.add(CONSTANTS.SPECTATOR_ROLE_ID);
+        await member.roles.add(CONSTANTS.ONBOARDING_ROLE_ID);
     }
 
     await logger({

--- a/src/lib/addMemberStatusRole.ts
+++ b/src/lib/addMemberStatusRole.ts
@@ -1,0 +1,12 @@
+import { CommandInteractionOption, CacheType, GuildMember } from 'discord.js';
+import { CONSTANTS } from '../constants';
+
+export const addMemberStatusRole = (
+    member: GuildMember,
+    status: CommandInteractionOption<CacheType>,
+) => {
+    status!.value !== 'Other' &&
+        member.roles.add(
+            CONSTANTS.MEMBER_STATUSES[status!.value as keyof typeof CONSTANTS.MEMBER_STATUSES],
+        );
+};

--- a/src/lib/deleteMessage.ts
+++ b/src/lib/deleteMessage.ts
@@ -1,9 +1,11 @@
-import { GuildMember, TextChannel, Message } from 'discord.js';
-import { client } from '..';
+import { GuildMember, TextChannel, Message, CacheType, CommandInteraction } from 'discord.js';
 import { CONSTANTS } from '../constants';
 
-export const deleteOnBoardingMessage = async (member: GuildMember) => {
-    const onBoardingChannel = (await client.channels.fetch(
+export const deleteOnBoardingMessage = async (
+    interaction: CommandInteraction<CacheType>,
+    member: GuildMember,
+) => {
+    const onBoardingChannel = (await interaction.client.channels.fetch(
         CONSTANTS.ONBOARDING_CHANNEL_ID,
     )) as TextChannel;
 

--- a/src/lib/deleteMessage.ts
+++ b/src/lib/deleteMessage.ts
@@ -1,0 +1,18 @@
+import { GuildMember, TextChannel, Message } from 'discord.js';
+import { client } from '..';
+import { CONSTANTS } from '../constants';
+
+export const deleteOnBoardingMessage = async (member: GuildMember) => {
+    const onBoardingChannel = (await client.channels.fetch(
+        CONSTANTS.ONBOARDING_CHANNEL_ID,
+    )) as TextChannel;
+
+    const onBoardingMessages = await onBoardingChannel.messages.fetch({ limit: 10 });
+    const message = onBoardingMessages.find((message: Message) =>
+        message.content.includes(member.id),
+    );
+
+    if (message) {
+        await message.delete();
+    }
+};

--- a/src/lib/deleteMessage.ts
+++ b/src/lib/deleteMessage.ts
@@ -11,7 +11,7 @@ export const deleteOnBoardingMessage = async (
 
     const onBoardingMessages = await onBoardingChannel.messages.fetch({ limit: 10 });
     const message = onBoardingMessages.find((message: Message) =>
-        message.content.includes(member.id),
+        message.content.includes(member.user.tag),
     );
 
     if (message) {

--- a/src/utils/embed-message.ts
+++ b/src/utils/embed-message.ts
@@ -4,6 +4,7 @@ interface EmbedMessage {
     title: string;
     description: string;
     color: ColorResolvable;
+    status?: string;
     author?: EmbedAuthorData;
     thumbnail?: string;
     links?: { name: string; value: string; inline: boolean }[];
@@ -27,6 +28,9 @@ export const embedMessage = (data: EmbedMessage) => {
     }
 
     author && message.setAuthor(author);
+
+    data.status && message.addField('Status', data.status);
+    console.log({ data, message });
     message.setColor(color).setTitle(title).setDescription(description).setTimestamp();
 
     return message;


### PR DESCRIPTION
1. New member accepts community guidelines (Receiving `onboarding` role)
2. Member is messaged in the `onboarding` channel with instructions on using `/intro` command
3. Member uses `/intro` command. The `onboarding` role is removed and the `member` role is added

Notes: 
- New members (no roles) only have access to community guidelines
- Members with `onboarding` role can only see the `onboarding`, and `community-guidelines` channels
- Members can see all channels except `on-boarding` channel